### PR TITLE
Fixes alarmpanel not disabling disarm codepad.

### DIFF
--- a/components/nspanel_lovelace/cards.cpp
+++ b/components/nspanel_lovelace/cards.cpp
@@ -184,8 +184,7 @@ std::string &AlarmCard::render(std::string &buffer) {
   buffer.append(1, SEPARATOR).append(this->status_icon_->render());
 
   // Only disable keypad when alarm is disarmed, since arming always requires code
-  if (this->alarm_entity_->is_state(entity_state::unknown) ||
-      this->alarm_entity_->is_state(entity_state::disarmed)) {
+  if (this->alarm_entity_->is_state(entity_state::disarmed)) {
         buffer.append(1, SEPARATOR)
         .append(this->show_keypad_ ? 
           generic_type::enable : generic_type::disable);

--- a/components/nspanel_lovelace/cards.cpp
+++ b/components/nspanel_lovelace/cards.cpp
@@ -183,9 +183,16 @@ std::string &AlarmCard::render(std::string &buffer) {
 
   buffer.append(1, SEPARATOR).append(this->status_icon_->render());
 
-  buffer.append(1, SEPARATOR)
-    .append(this->show_keypad_ ? 
-      generic_type::enable : generic_type::disable);
+  // Only disable keypad when alarm is disarmed, since arming always requires code
+  if (this->alarm_entity_->is_state(entity_state::unknown) ||
+      this->alarm_entity_->is_state(entity_state::disarmed)) {
+        buffer.append(1, SEPARATOR)
+        .append(this->show_keypad_ ? 
+          generic_type::enable : generic_type::disable);
+  } else {
+    buffer.append(1, SEPARATOR)
+        .append(generic_type::enable);
+  }
 
   buffer.append(1, SEPARATOR)
     .append(this->status_icon_flashing_ ? 


### PR DESCRIPTION
The property code_arm_required of home assitant alarm panel, should only remove the keypad when alarm is not enabled.
When the alarm is armed, the keypad should be always visible.

In the previous code setting the property code_arm_required  to false, also caused the keypad to be hidden when armed. This is not right. And was fixes in this pull request.