### PR TITLE
Fix screensaver notifications not timing out

### DIFF
--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -1335,6 +1335,7 @@ void NSPanelLovelace::notify_on_screensaver(
     // hide the notification after a period of time
     this->set_timeout(timeout_ms, [this]() {
       if (!this->current_page_->is_type(page_type::screensaver)) return;
+      force_current_page_update_ = true;
       this->render_screensaver();
     });
   }


### PR DESCRIPTION
Notifications on screensaver do not correctly timeout, they will just stay there until the screen is clicked.

Adding `force_current_page_update_ = true;` will force the screen to refresh when timeout is called.

The issue lays in `this->render_screensaver();` which has a check if the screen is already on the requested screen, thus it will not update and remove the notification.