### PR TITLE
Support 2025.10.x ESPHome

### DIFF
--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2272,7 +2272,11 @@ void NSPanelLovelace::call_ha_service_(
     const std::string &service,
     const std::map<std::string, std::string> &data,
     const std::map<std::string, std::string> &data_template) {
-  api::HomeassistantActionRequest resp;
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,10,0)
+    api::HomeassistantActionRequest resp;
+  #else
+    api::HomeassistantServiceResponse resp;
+  #endif
   #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
     resp.set_service(esphome::StringRef(service));
   #else
@@ -2308,7 +2312,11 @@ void NSPanelLovelace::call_ha_service_(
     resp.data_template.push_back(kv);
   }
 
-  api::global_api_server->send_homeassistant_action(resp);
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,10,0)
+    api::global_api_server->send_homeassistant_action(resp);
+  #else
+    api::global_api_server->send_homeassistant_service_call(resp);
+  #endif
 }
 
 void NSPanelLovelace::on_entity_state_update_(std::string entity_id, std::string state) {

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2272,7 +2272,7 @@ void NSPanelLovelace::call_ha_service_(
     const std::string &service,
     const std::map<std::string, std::string> &data,
     const std::map<std::string, std::string> &data_template) {
-  api::HomeassistantServiceResponse resp;
+  api::HomeAssistantStateResponse resp;
   #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
     resp.set_service(esphome::StringRef(service));
   #else
@@ -2308,7 +2308,7 @@ void NSPanelLovelace::call_ha_service_(
     resp.data_template.push_back(kv);
   }
 
-  api::global_api_server->send_homeassistant_service_call(resp);
+  api::global_api_server->send_homeassistant_action(resp);
 }
 
 void NSPanelLovelace::on_entity_state_update_(std::string entity_id, std::string state) {

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2272,7 +2272,7 @@ void NSPanelLovelace::call_ha_service_(
     const std::string &service,
     const std::map<std::string, std::string> &data,
     const std::map<std::string, std::string> &data_template) {
-  api::HomeAssistantStateResponse resp;
+  api::HomeassistantActionRequest resp;
   #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
     resp.set_service(esphome::StringRef(service));
   #else


### PR DESCRIPTION
If version 2025.10+ then use the new renamed classes:
https://www.esphome.io/changelog/2025.10.0/#api-changes

solves: [49](https://github.com/olicooper/esphome-nspanel-lovelace-native/issues/49)