### PR TITLE
Fix for 2025.11

### DIFF
--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2272,7 +2272,11 @@ void NSPanelLovelace::call_ha_service_(
     const std::string &service,
     const std::map<std::string, std::string> &data,
     const std::map<std::string, std::string> &data_template) {
-  api::HomeassistantServiceResponse resp;
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,10,0)
+    api::HomeassistantActionRequest resp;
+  #else
+    api::HomeassistantServiceResponse resp;
+  #endif
   #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
     resp.set_service(esphome::StringRef(service));
   #else
@@ -2308,7 +2312,11 @@ void NSPanelLovelace::call_ha_service_(
     resp.data_template.push_back(kv);
   }
 
-  api::global_api_server->send_homeassistant_service_call(resp);
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,10,0)
+    api::global_api_server->send_homeassistant_action(resp);
+  #else
+    api::global_api_server->send_homeassistant_service_call(resp);
+  #endif
 }
 
 void NSPanelLovelace::on_entity_state_update_(std::string entity_id, std::string state) {

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2291,7 +2291,9 @@ void NSPanelLovelace::call_ha_service_(
       ESP_LOGD(TAG, "Call HA: %s", service.c_str());
   #endif
   
-  resp.data.init(data.size());
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,11,0)
+    resp.data.init(data.size());
+  #endif
   for (auto &it : data) {
     api::HomeassistantServiceMap kv;
     #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
@@ -2303,7 +2305,9 @@ void NSPanelLovelace::call_ha_service_(
     resp.data.push_back(kv);
   }
 
-  resp.data_template.init(data_template.size());
+  #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,11,0)
+    resp.data_template.init(data_template.size());
+  #endif
   for (auto &it : data_template) {
     api::HomeassistantServiceMap kv;
     #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -2290,7 +2290,8 @@ void NSPanelLovelace::call_ha_service_(
     else
       ESP_LOGD(TAG, "Call HA: %s", service.c_str());
   #endif
-
+  
+  resp.data.init(data.size());
   for (auto &it : data) {
     api::HomeassistantServiceMap kv;
     #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)
@@ -2301,6 +2302,8 @@ void NSPanelLovelace::call_ha_service_(
     kv.value = it.second;
     resp.data.push_back(kv);
   }
+
+  resp.data_template.init(data_template.size());
   for (auto &it : data_template) {
     api::HomeassistantServiceMap kv;
     #if ESPHOME_VERSION_CODE >= VERSION_CODE(2025,8,0)


### PR DESCRIPTION
In the refactoring of ESP 2025.11, the FixedVector maps used needs to be initialized and sized before the data (i.e. entity id's etc.) can be added. This is my attempt at achieving just that. I tested it on my 1 panel and it seems to work.