### PR TITLE
Add workflow to build with ESPHome

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        version: [2025.11.0, dev]
+        version: [stable]
         variant: [basic-example, advanced-example]
     container:
       image: ghcr.io/esphome/esphome:${{ matrix.version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,22 @@
 name: Build
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - dev
-  workflow_dispatch:
+    paths:
+      - "components/nspanel_lovelace/**"
+      - ".github/workflows/build.yaml"
+      - "*example.yaml"
+
   pull_request:
+    branches:
+      - dev
+    paths:
+      - "components/nspanel_lovelace/**"
+      - "*example.yaml"
 
 jobs:
   test:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 2
       matrix:
         version: [stable]
-        variant: [basic-example, advanced-example]
+        variant: [advanced-example]
     container:
       image: ghcr.io/esphome/esphome:${{ matrix.version }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        version: [2025.11.0, dev]
+        variant: [basic-example, advanced-example]
+    container:
+      image: ghcr.io/esphome/esphome:${{ matrix.version }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Copy test secrets
+      run: |
+        cp secrets-example.yaml secrets.yaml
+    - run: esphome compile ${{ matrix.variant }}.yaml


### PR DESCRIPTION
This will build the repo-hosted **examples** with latest `stable` version of ESPHome, useful to ensure the changes are valid and compiling. Supports testing older / multiple versions.

At the moment this workflow will ❌ not pass, because recent ESPHome version 2026.1.1 has some new breaking changes that should be fixed in this repo.