### PR TITLE
fix for esphome PR #12673

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A special thanks goes to these great projects for making this possible:
 
 # Installation
 
+This library only works with the latest minor versions of ESPHome, older versions are not officially supported but may still work.
+
 The installation of ESPHome on the ESP32 follows the standard ESPHome build method e.g. `esphome run --device COM6 basic-example.yaml`. It is possible to do OTA updates with the ESPHome CLI after the initial upload.
 
 For the GUI, this project relies on the HMI TFT firmware from the [ESPHome NSPanel Lovelace UI](https://github.com/sairon/esphome-nspanel-lovelace-ui) project. 

--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -497,7 +497,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,
-    cv.require_esphome_version(2025,8,0),
+    cv.require_esphome_version(2026,4,0),
     #cv.only_with_esp_idf,
     validate_config
 )
@@ -619,8 +619,8 @@ async def to_code(config):
                     if string.endswith("TEST_DEVICE_MODE")]
     if is_test_mode:
         _LOGGER.info(f"[nspanel_lovelace] TEST DEVICE MODE ACTIVE, PSRAM DISABLED")
-    # NSPanel has non-standard PSRAM pins which are not modifiable when building for Arduino
-    elif core.CORE.is_esp32:
+    elif not core.CORE.using_arduino or cv.Version.parse(ESPHOME_VERSION) >= cv.Version(2026,6,0):
+        # NSPanel has non-standard PSRAM pins
         cg.add_define("USE_PSRAM")
         esp32.add_idf_sdkconfig_option(
             f"CONFIG_{esp32.get_esp32_variant().upper()}_SPIRAM_SUPPORT", True
@@ -670,17 +670,20 @@ async def to_code(config):
         # cg.add_define("USE_NSPANEL_TFT_UPLOAD")
         # core.CORE.add_define("USE_NSPANEL_TFT_UPLOAD")
         cg.add_build_flag("-DUSE_NSPANEL_TFT_UPLOAD")
-        if core.CORE.using_arduino:
-            cg.add_library("WiFiClientSecure", None)
-            cg.add_library("HTTPClient", None)
-        elif core.CORE.is_esp32:
-            ## todo: Remove this condition by esphome version 2026.6.x
-            if hasattr(esp32, "include_builtin_idf_component"):
-                esp32.include_builtin_idf_component("esp_http_client")
-            esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_INSECURE", True)
-            esp32.add_idf_sdkconfig_option(
-                "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True
-            )
+
+        ## FIXME: HTTPClient missing when building for Arduino so compilation fails. Using IDF version instead for now
+        # if core.CORE.using_arduino:
+        #     # cg.add_library("WiFiClientSecure", None)
+        #     cg.add_library("NetworkClientSecure", None)
+        #     cg.add_library("HTTPClient", None)
+        # else:
+        ## todo: Remove this condition by esphome version 2026.6.x
+        if hasattr(esp32, "include_builtin_idf_component"):
+            esp32.include_builtin_idf_component("esp_http_client")
+        esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_INSECURE", True)
+        esp32.add_idf_sdkconfig_option(
+            "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True
+        )
 
     if CONF_SCREENSAVER in config:
         cg.add(nspanel.set_display_timeout(config[CONF_SLEEP_TIMEOUT]))

--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -620,7 +620,7 @@ async def to_code(config):
     if is_test_mode:
         _LOGGER.info(f"[nspanel_lovelace] TEST DEVICE MODE ACTIVE, PSRAM DISABLED")
     # NSPanel has non-standard PSRAM pins which are not modifiable when building for Arduino
-    elif core.CORE.using_esp_idf:
+    elif core.CORE.is_esp32:
         cg.add_define("USE_PSRAM")
         esp32.add_idf_sdkconfig_option(
             f"CONFIG_{esp32.get_esp32_variant().upper()}_SPIRAM_SUPPORT", True
@@ -673,7 +673,7 @@ async def to_code(config):
         if core.CORE.using_arduino:
             cg.add_library("WiFiClientSecure", None)
             cg.add_library("HTTPClient", None)
-        elif core.CORE.using_esp_idf:
+        elif core.CORE.is_esp32:
             ## todo: Remove this condition by esphome version 2026.6.x
             if hasattr(esp32, "include_builtin_idf_component"):
                 esp32.include_builtin_idf_component("esp_http_client")
@@ -975,4 +975,4 @@ async def to_code(config):
 # if CORE.using_arduino:
 #     cg.add_library("WiFi", None)
 # else:
-#     if CORE.using_esp_idf:
+#     if CORE.is_esp32:

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -1466,31 +1466,26 @@ uint16_t NSPanelLovelace::recv_ret_string_(std::string &response, uint32_t timeo
 #endif
 }
 
-#ifdef USE_ARDUINO
-void NSPanelLovelace::set_reparse_mode_(bool active) {
-  // if (this->reparse_mode_ == active) return;
+// #ifdef USE_ARDUINO
+// void NSPanelLovelace::set_reparse_mode_(bool active) {
+//   // if (this->reparse_mode_ == active) return;
 
-  if (active) {
-    this->send_nextion_command_("recmod=1");
-  } else {
-    this->send_nextion_command_("DRAKJHSUYDGBNCJHGJKSHBDN");
-    this->send_nextion_command_("recmod=0");
-    this->send_nextion_command_("recmod=0");
-    this->send_nextion_command_("connect");
-  }
+//   if (active) {
+//     this->send_nextion_command_("recmod=1");
+//   } else {
+//     this->send_nextion_command_("DRAKJHSUYDGBNCJHGJKSHBDN");
+//     this->send_nextion_command_("recmod=0");
+//     this->send_nextion_command_("recmod=0");
+//     this->send_nextion_command_("connect");
+//   }
 
-  this->reparse_mode_ = active;
-}
-#endif // USE_ARDUINO
+//   this->reparse_mode_ = active;
+// }
+// #endif // USE_ARDUINO
 #endif // USE_NSPANEL_TFT_UPLOAD
 
 void NSPanelLovelace::init_display_(int baud_rate) {
-  // hopefully on NSPanel it should always be an ESP32ArduinoUARTComponent instance
-#ifdef USE_ESP_IDF
   auto *uart = reinterpret_cast<uart::IDFUARTComponent*>(this->parent_);
-#else
-  auto *uart = reinterpret_cast<uart::ESP32ArduinoUARTComponent*>(this->parent_);
-#endif
   uart->set_baud_rate(baud_rate);
   uart->setup();
 }

--- a/components/nspanel_lovelace/nspanel_lovelace.h
+++ b/components/nspanel_lovelace/nspanel_lovelace.h
@@ -19,17 +19,14 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/api/custom_api_device.h"
 
-#ifdef USE_ESP_IDF
 #include <driver/gpio.h>
 #include "esphome/components/uart/uart_component_esp_idf.h"
 #ifdef USE_NSPANEL_TFT_UPLOAD
+// #ifndef USE_ARDUINO
 #include <esp_http_client.h>
-#endif
-#else
-#ifdef USE_NSPANEL_TFT_UPLOAD
-#include <HTTPClient.h>
-#endif
-#include "esphome/components/uart/uart_component_esp32_arduino.h"
+// #else
+// #include <HTTPClient.h>
+// #endif
 #endif
 
 #ifdef USE_TIME
@@ -146,7 +143,7 @@ public:
    */
   void soft_reset_display() {
     // this->send_nextion_command_("rest"); // only for stock FW
-#ifdef USE_ESP_IDF
+#ifndef USE_ARDUINO
     gpio_set_level(GPIO_NUM_4, 1);
     vTaskDelay(pdMS_TO_TICKS(1000));
     gpio_set_level(GPIO_NUM_4, 0);
@@ -184,9 +181,9 @@ protected:
   void init_display_(int baud_rate);
 #ifdef USE_NSPANEL_TFT_UPLOAD
   uint16_t recv_ret_string_(std::string &response, uint32_t timeout, bool recv_flag);
-#ifdef USE_ARDUINO
-  void set_reparse_mode_(bool active);
-#endif
+// #ifdef USE_ARDUINO
+//   void set_reparse_mode_(bool active);
+// #endif
 #endif
   void send_nextion_command_(const std::string &command);
 
@@ -314,13 +311,13 @@ protected:
   uint32_t content_length_ = 0;
   size_t tft_size_ = 0;
   bool upload_first_chunk_sent_ = false;
-#ifdef USE_ESP_IDF
+// #ifndef USE_ARDUINO
   int upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start);
-#else // USE_ARDUINO
-  uint8_t *transfer_buffer_ = nullptr;
-  size_t transfer_buffer_size_;
-  int upload_by_chunks_(HTTPClient *http, const std::string &url, uint32_t &range_start);
-#endif
+// #else
+//   uint8_t *transfer_buffer_ = nullptr;
+//   size_t transfer_buffer_size_;
+//   int upload_by_chunks_(HTTPClient *http, const std::string &url, uint32_t &range_start);
+// #endif
   bool upload_end_(bool successful);
 #endif // USE_NSPANEL_TFT_UPLOAD
 };

--- a/components/nspanel_lovelace/nspanel_lovelace_upload_arduino.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload_arduino.cpp
@@ -1,3 +1,4 @@
+#if 0 // Disable Arduino code until we decide if we need to remove it (using IDF version instead)
 #ifdef USE_NSPANEL_TFT_UPLOAD
 #ifdef USE_ARDUINO
 
@@ -302,3 +303,4 @@ bool NSPanelLovelace::upload_end_(bool successful) {
 
 #endif // USE_ARDUINO
 #endif // USE_NSPANEL_TFT_UPLOAD
+#endif // if 0

--- a/components/nspanel_lovelace/nspanel_lovelace_upload_idf.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace_upload_idf.cpp
@@ -1,5 +1,5 @@
 #ifdef USE_NSPANEL_TFT_UPLOAD
-#ifdef USE_ESP_IDF
+// #ifndef USE_ARDUINO
 
 // Adapted from: https://github.com/esphome/esphome/blob/5b6b7c0d15098f7477bae68329fe76a1d8993cf5/esphome/components/nextion/nextion_upload_idf.cpp
 // See:
@@ -458,5 +458,5 @@ bool NSPanelLovelace::upload_end_(bool successful) {
 }  // namespace nspanel_lovelace
 }  // namespace esphome
 
-#endif // USE_ESP_IDF
+// #endif // not USE_ARDUINO
 #endif // USE_NSPANEL_TFT_UPLOAD

--- a/test.yaml
+++ b/test.yaml
@@ -24,12 +24,11 @@ esphome:
   name_add_mac_suffix: true
   comment: "NSPanel test device"
   build_path: ./.build/${node_name}
-  platformio_options:
-    build_flags:
-      - -DTEST_DEVICE_MODE
-      - -DFAKE_TFT_UPLOAD
-      # - -Wall
-      # - -Wextra
+  build_flags:
+    - -DTEST_DEVICE_MODE
+    - -DFAKE_TFT_UPLOAD
+    # - -Wall
+    # - -Wextra
 
 esp32:
   board: lolin32_lite


### PR DESCRIPTION
This component no longer builds with latest esphome HA addon. This PR makes the changes necessary to fix this.

https://developers.esphome.io/blog/2026/01/12/use_esp_idf-deprecated-in-favor-of-use_esp32/