### PR TITLE
feat: support experimental_vertical_ui configuration for vertical light details popups

### DIFF
--- a/components/nspanel_lovelace/__init__.py
+++ b/components/nspanel_lovelace/__init__.py
@@ -121,6 +121,7 @@ CONF_ICON_COLOR = "color"
 CONF_ENTITY_ID = "entity_id"
 CONF_SLEEP_TIMEOUT = "sleep_timeout"
 CONF_DEFAULT_CARD = "default_card"
+CONF_EXP_VERT_UI = "experimental_vertical_ui"
 
 CONF_LOCALE = "locale"
 CONF_TEMPERATURE_UNIT = "temperature_unit"
@@ -449,6 +450,7 @@ CONFIG_SCHEMA = cv.All(
         cv.GenerateID(): cv.declare_id(NSPanelLovelace),
         # Timeout range from 0s to 65s. 0s means disable screensaver.
         cv.Optional(CONF_SLEEP_TIMEOUT, default=10): cv.int_range(0, 65),
+        cv.Optional(CONF_EXP_VERT_UI, default=False): cv.boolean,
         cv.Optional(CONF_MODEL, default='eu'): cv.one_of('eu', 'us-l', 'us-p'),
         cv.Optional(CONF_DEFAULT_CARD): cv.string_strict,
         cv.Optional(CONF_LOCALE, default={}): SCHEMA_LOCALE,
@@ -684,6 +686,9 @@ async def to_code(config):
 
     if CONF_SCREENSAVER in config:
         cg.add(nspanel.set_display_timeout(config[CONF_SLEEP_TIMEOUT]))
+
+    if CONF_EXP_VERT_UI in config:
+        cg.add(nspanel.set_global_vertical_ui(config[CONF_EXP_VERT_UI]))
 
     locale_config = config[CONF_LOCALE]
     global translationJson

--- a/components/nspanel_lovelace/nspanel_lovelace.cpp
+++ b/components/nspanel_lovelace/nspanel_lovelace.cpp
@@ -461,7 +461,8 @@ void NSPanelLovelace::set_display_dim(uint8_t inactive, uint8_t active) {
     // brightness when active (when buttons pressed)
     .append(esphome::to_string(this->display_active_dim_)).append(1, SEPARATOR)
     // background colour when active (not screensaver background, defaults to ha-dark)
-    .append(esphome::to_string(6371));
+    .append(esphome::to_string(6371)).append(2, SEPARATOR)
+    .append(esphome::to_string(this->global_vertical_ui_ ? 1 : 0));
   
   this->send_buffered_command_();
 }

--- a/components/nspanel_lovelace/nspanel_lovelace.h
+++ b/components/nspanel_lovelace/nspanel_lovelace.h
@@ -131,6 +131,7 @@ public:
 
   bool get_double_tap_to_unlock() const { return this->double_tap_to_unlock_; }
   void set_double_tap_to_unlock(bool value) { this->double_tap_to_unlock_ = value; }
+  void set_global_vertical_ui(bool val) { this->global_vertical_ui_ = val; }
   
   void render_screensaver_page() { this->render_page_(render_page_option::screensaver_page); }
   void render_next_page() { this->render_page_(render_page_option::next); }
@@ -295,6 +296,7 @@ protected:
   PageManager page_mgr_;
   std::string popup_page_current_uuid_;
   bool force_current_page_update_ = false;
+  bool global_vertical_ui_{false};
   std::vector<std::shared_ptr<Entity>> entities_;
   std::vector<std::shared_ptr<StatefulPageItem>> stateful_page_items_;
   Screensaver* screensaver_ = nullptr;


### PR DESCRIPTION
This enables the vertical slider in original HMI project, see "Ceiling Lights" page in screenshot below

<img width="1146" height="2779" alt="image" src="https://github.com/user-attachments/assets/0831caab-94af-453d-bfb8-117968f89e57" />

Just like the jobr99/nspanel-lovelace-ui project the feature is marked as experimental.