### PR TITLE
feat: display numeric sensor state values on grid cards with auto-formatting and font sizes

### DIFF
--- a/components/nspanel_lovelace/card_base.cpp
+++ b/components/nspanel_lovelace/card_base.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "page_base.h"
 #include "page_item_base.h"
+#include "page_item_visitor.h"
 #include <cstring>
 #include <stdint.h>
 #include <string>
@@ -37,6 +38,9 @@ std::string &Card::render(std::string &buffer) {
   this->render_nav(buffer);
 
   for (auto& item : this->items_) {
+    if (auto* card_item = page_item_cast<CardItem>(item.get())) {
+      card_item->set_parent_page_type(this->type_);
+    }
     buffer.append(1, SEPARATOR).append(item->render());
   }
 

--- a/components/nspanel_lovelace/card_base.h
+++ b/components/nspanel_lovelace/card_base.h
@@ -59,10 +59,15 @@ public:
 
   void accept(PageItemVisitor& visitor) override;
 
+  page_type get_parent_page_type() const { return this->parent_page_type_; }
+  void set_parent_page_type(page_type type) { this->parent_page_type_ = type; }
+
 protected:
   // output: type~internalName~icon~iconColor~displayName~
   std::string &render_(std::string &buffer) override;
   uint16_t get_render_buffer_reserve_() const override;
+
+  page_type parent_page_type_{page_type::cardGrid};
 };
 
 } // namespace nspanel_lovelace

--- a/components/nspanel_lovelace/card_items.cpp
+++ b/components/nspanel_lovelace/card_items.cpp
@@ -43,7 +43,11 @@ std::string &GridCardEntityItem::render_(std::string &buffer) {
     float f_val = std::strtof(temp_val.c_str(), &endptr);
     if (endptr != temp_val.c_str()) {
       char formatted[16];
-      std::snprintf(formatted, sizeof(formatted), "%.1f", f_val);
+      if (this->get_parent_page_type() == page_type::cardGrid2) {
+        std::snprintf(formatted, sizeof(formatted), "%.0f", f_val);
+      } else {
+        std::snprintf(formatted, sizeof(formatted), "%.1f", f_val);
+      }
       temp_val = formatted;
     }
     
@@ -52,6 +56,12 @@ std::string &GridCardEntityItem::render_(std::string &buffer) {
     }
     if (!temp_val.empty() && temp_val.back() == '.') {
       temp_val.pop_back();
+    }
+    
+    if (this->get_parent_page_type() == page_type::cardGrid2) {
+      temp_val.append("¬2");
+    } else {
+      temp_val.append("¬3");
     }
     
     this->icon_value_ = reinterpret_cast<const icon_char_t *>(temp_val.c_str());

--- a/components/nspanel_lovelace/card_items.cpp
+++ b/components/nspanel_lovelace/card_items.cpp
@@ -7,6 +7,7 @@
 #include "translations.h"
 #include "types.h"
 #include <type_traits>
+#include <cstdlib>
 
 namespace esphome {
 namespace nspanel_lovelace {
@@ -29,6 +30,41 @@ GridCardEntityItem::GridCardEntityItem(
 }
 
 void GridCardEntityItem::accept(PageItemVisitor& visitor) { visitor.visit(*this); }
+
+std::string &GridCardEntityItem::render_(std::string &buffer) {
+  const icon_char_t *orig_icon = this->icon_value_;
+  bool restore = false;
+  std::string temp_val;
+  
+  if (this->entity_->is_type(entity_type::sensor) && !this->icon_value_overridden_) {
+    temp_val = this->entity_->get_state();
+    
+    char *endptr = nullptr;
+    float f_val = std::strtof(temp_val.c_str(), &endptr);
+    if (endptr != temp_val.c_str()) {
+      char formatted[16];
+      std::snprintf(formatted, sizeof(formatted), "%.1f", f_val);
+      temp_val = formatted;
+    }
+    
+    if (temp_val.length() > 4) {
+      temp_val = temp_val.substr(0, 4);
+    }
+    if (!temp_val.empty() && temp_val.back() == '.') {
+      temp_val.pop_back();
+    }
+    
+    this->icon_value_ = reinterpret_cast<const icon_char_t *>(temp_val.c_str());
+    restore = true;
+  }
+
+  CardItem::render_(buffer);
+
+  if (restore) {
+    this->icon_value_ = orig_icon;
+  }
+  return buffer;
+}
 
 /*
  * =============== EntitiesCardEntityItem ===============

--- a/components/nspanel_lovelace/card_items.h
+++ b/components/nspanel_lovelace/card_items.h
@@ -23,6 +23,9 @@ public:
   // virtual ~GridCardEntityItem() {}
 
   void accept(PageItemVisitor& visitor) override;
+
+protected:
+  std::string &render_(std::string &buffer) override;
 };
 
 /*


### PR DESCRIPTION
### Summary
    This PR adds support for displaying numeric sensor state values directly inside grid card items
  (`cardGrid` and `cardGrid2`) in place of standard icons.

### Key Changes
1. **Grid Card Auto-Formatting**: 
   - On **`cardGrid`** (wider, 3 columns), it formats float states to 1 decimal place (`%.1f` / e.g.
`23.5`) and uses Font 3 (Size 48) so that it matches standard icon sizes.
   - On **`cardGrid2`** (narrower, 4 columns), it automatically formats float states to 0 decimal
places (`%.0f` / e.g. `23`) and uses Font 2 (Size 32) to fit the narrower boundary constraints.
2. **HMI Suffix Insertion**: Inserts `¬3` or `¬2` suffix into the rendered state string directly,
allowing the Nextion screen to automatically adapt and scale text without needing manual YAML
configuration changes.